### PR TITLE
Fix bash syntax

### DIFF
--- a/armbian/customize-image-fluidd.sh
+++ b/armbian/customize-image-fluidd.sh
@@ -127,7 +127,7 @@ prepare_build() {
     PACKAGE_LIST+=" python3-virtualenv virtualenv python3-dev libffi-dev build-essential python3-cffi python3-libxml2"
     PACKAGE_LIST+=" libncurses-dev libusb-dev stm32flash libnewlib-arm-none-eabi gcc-arm-none-eabi binutils-arm-none-eabi "
     apt update
-    apt install -y $PACKAGE_LIST
+    apt install -y "$PACKAGE_LIST"
 
     # Ensure the debian user exists
     useradd debian -d /home/debian -G tty,dialout -m -s /bin/bash -e -1

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -16,20 +16,20 @@ case $VERSION in
     ;; 
 esac
 
-if [ "x$LOCAL" == "xlocal" ]; then
+if [ "$LOCAL" == "local" ]; then
     BUILD_PREFIX="."
 else
     BUILD_PREFIX=".."
 fi
 
 BUILD_DIR="${BUILD_PREFIX}/build-${VERSION}"
-if ! test -d $BUILD_DIR ; then
+if ! test -d "$BUILD_DIR" ; then
     echo "$BUILD_DIR missing"
     git clone https://github.com/armbian/build $BUILD_DIR
 fi
 
-ROOT_DIR=`pwd`
-TAG=`git describe --always --tags`
+ROOT_DIR=$(pwd)
+TAG=$(git describe --always --tags)
 NAME="rebuild-${VERSION}-${TAG}"
 
 cd $BUILD_DIR
@@ -37,24 +37,24 @@ git checkout v23.05.2
 git pull
 rm -rf "userpatches"
 
-cd $ROOT_DIR
+cd "$ROOT_DIR"
 cp -r "userpatches" "${BUILD_DIR}"
-cp armbian/customize-image-${VERSION}.sh ${BUILD_DIR}/userpatches/customize-image.sh
-cp armbian/recore.csc ${BUILD_DIR}/config/boards
+cp armbian/customize-image-"${VERSION}".sh "${BUILD_DIR}"/userpatches/customize-image.sh
+cp armbian/recore.csc "${BUILD_DIR}"/config/boards
 rm -f "${BUILD_DIR}/patch/u-boot/u-boot-sunxi/allwinner-boot-splash.patch"
 
-if [ "x$VERSION" == "xreflash" ]; then
-    cp armbian/watermark-reflash.png ${BUILD_DIR}/packages/plymouth-theme-armbian/watermark.png
+if [ "$VERSION" == "reflash" ]; then
+    cp armbian/watermark-reflash.png "${BUILD_DIR}"/packages/plymouth-theme-armbian/watermark.png
 else
-    cp armbian/watermark.png ${BUILD_DIR}/packages/plymouth-theme-armbian/watermark.png
+    cp armbian/watermark.png "${BUILD_DIR}"/packages/plymouth-theme-armbian/watermark.png
 fi
 
-echo "${NAME}" > ${BUILD_DIR}/userpatches/overlay/rebuild/rebuild-version
+echo "${NAME}" > "${BUILD_DIR}"/userpatches/overlay/rebuild/rebuild-version
 
-cd $BUILD_DIR
+cd "$BUILD_DIR"
 DOCKER_EXTRA_ARGS="--cpus=12" ./compile.sh rebuild
-IMG=`ls -1 output/images/ | grep "img.xz$"`
+IMG=$(ls -1 output/images/ | grep "img.xz$")
 
-cd $ROOT_DIR
-mv $BUILD_DIR/output/images/$IMG "${BUILD_PREFIX}/images/${NAME}.img.xz"
+cd "$ROOT_DIR"
+mv "$BUILD_DIR"/output/images/"$IMG" "${BUILD_PREFIX}/images/${NAME}.img.xz"
 echo "🍰 Finished building ${NAME}"

--- a/userpatches/overlay/klipper/install-recore.sh
+++ b/userpatches/overlay/klipper/install-recore.sh
@@ -89,7 +89,7 @@ verify_ready()
 {
     if [ "$EUID" -eq 0 ]; then
         echo "This script must not run as root"
-        exit -1
+        exit 1
     fi
 }
 


### PR DESCRIPTION
This branch is meant to fix a few minor bash syntax issues picked up by VSCode.
Mostly revolves around quoting variables to avoid whitespace errors.