### PR TITLE
Enhance/use ansible build

### DIFF
--- a/armbian/customize-image-fluidd.sh
+++ b/armbian/customize-image-fluidd.sh
@@ -127,7 +127,7 @@ prepare_build() {
     PACKAGE_LIST+=" python3-virtualenv virtualenv python3-dev libffi-dev build-essential python3-cffi python3-libxml2"
     PACKAGE_LIST+=" libncurses-dev libusb-dev stm32flash libnewlib-arm-none-eabi gcc-arm-none-eabi binutils-arm-none-eabi "
     apt update
-    apt install -y $PACKAGE_LIST
+    apt install -y "$PACKAGE_LIST"
 
     # Ensure the debian user exists
     useradd debian -d /home/debian -G tty,dialout -m -s /bin/bash -e -1

--- a/armbian/customize-image-mainsail.sh
+++ b/armbian/customize-image-mainsail.sh
@@ -17,117 +17,15 @@ LINUXFAMILY=$2
 BOARD=$3
 BUILD_DESKTOP=$4
 
-install_klipper(){
-    echo "🍰 install Klipper"
-    cd /home/debian
-    git clone https://github.com/Klipper3d/klipper
-    cp /tmp/overlay/klipper/install-recore.sh /home/debian/klipper/scripts/
-    cp /tmp/overlay/klipper/recore.py /home/debian/klipper/klippy/extras/
-    cp /tmp/overlay/klipper/thermocouple.py /home/debian/klipper/klippy/extras/
-    cp /tmp/overlay/klipper/generic-recore-a6.cfg /home/debian/klipper/config/
-    cp /tmp/overlay/klipper/generic-recore-a7.cfg /home/debian/klipper/config/
-    # Add compatibility with A5. 
-    cp /tmp/overlay/klipper/recore_a5.py /home/debian/klipper/klippy/extras/
-    cp /tmp/overlay/klipper/recore_adc_temperature.py /home/debian/klipper/klippy/extras/
-    cp /tmp/overlay/klipper/recore_thermistor.py /home/debian/klipper/klippy/extras/
-    cp /tmp/overlay/klipper/generic-recore-a5.cfg /home/debian/klipper/config/
-    cp /tmp/overlay/klipper/tmc2209_a5.py /home/debian/klipper/klippy/extras/
-    cp /tmp/overlay/klipper/tmc2130_a5.py /home/debian/klipper/klippy/extras/
-
-	cp /tmp/overlay/klipper/flash-stm32 /usr/local/bin
-	cp /tmp/overlay/klipper/flash-stm32.service /etc/systemd/system/
-    mkdir -p /var/log/klipper_logs
-    chown debian:debian /var/log/klipper_logs
-    mkdir -p /opt/firmware/
-    cp /tmp/overlay/klipper/bl31.bin /opt/firmware/
-    chown -R debian:debian klipper
-    chmod +x /home/debian/klipper/scripts/install-recore.sh
-    su -c "/home/debian/klipper/scripts/install-recore.sh" debian
-    wget http://feeds.iagent.no/toolchains/or1k-linux-musl-11.2.0.tar.xz -P /opt
-    cd /opt
-    tar -xf /opt/or1k-linux-musl-11.2.0.tar.xz
-    rm /opt/or1k-linux-musl-11.2.0.tar.xz
-    cp /tmp/overlay/klipper/ar100.config /home/debian/klipper/.config
-    cd /home/debian/klipper/
-    export PATH=$PATH:/opt/output/bin
-	echo "export PATH=\$PATH:/opt/output/bin" >> /home/debian/.bashrc
-    make olddefconfig
-    make -j
-    cp /home/debian/klipper/out/ar100.bin /opt/firmware
-    cp /tmp/overlay/klipper/stm32f0.config /home/debian/klipper/.config
-    make olddefconfig
-    make -j
-    cp /home/debian/klipper/out/klipper.bin /opt/firmware/stm32.bin
-    chown -R debian:debian /home/debian/klipper
-	systemctl enable flash-stm32.service
+install_ansible(){
+    apt install ansible
+    cd /usr/src/
+    git clone https://github.com/intelligent-agent/Refactor.git
 }
 
-install_moonraker(){
-    echo "🍰 install Moonraker"
-    cd /home/debian
-    git clone https://github.com/Arksine/moonraker
-    chown -R debian:debian moonraker
-    su -c "/home/debian/moonraker/scripts/install-moonraker.sh" debian
-    su -c "/home/debian/moonraker/scripts/set-policykit-rules.sh" debian
-    cp /tmp/overlay/moonraker/moonraker.conf /home/debian/printer_data/config
-    cp /tmp/overlay/moonraker/recore.py /home/debian/moonraker/moonraker/components
-}
-
-install_mainsail(){
-    echo "🍰 install Mainsail"
-    cd /home/debian
-    wget https://github.com/intelligent-agent/mainsail/releases/latest/download/mainsail.zip
-    unzip mainsail.zip -d mainsail
-    chown -R debian:debian mainsail
-    cp /tmp/overlay/mainsail/mainsail.cfg /home/debian/printer_data/config
-}
-
-install_nginx(){
-    echo "🍰 install Nginx"
-    cp /tmp/overlay/nginx/upstreams.conf /etc/nginx/conf.d/
-    cp /tmp/overlay/nginx/common_vars.conf /etc/nginx/conf.d/
-    cp /tmp/overlay/nginx/mainsail /etc/nginx/sites-available
-    rm /etc/nginx/sites-enabled/default
-    ln -s /etc/nginx/sites-available/mainsail /etc/nginx/sites-enabled/mainsail   
-}
-
-install_bins(){
-    echo "🍰 install Bins"
-    cp /tmp/overlay/bins/* /usr/local/bin
-    chmod +x /usr/local/bin/*
-}
-
-install_klipperscreen() {
-    echo "🍰 install KlipperScreen"
-    cd /home/debian
-    git clone https://github.com/jordanruthe/KlipperScreen.git
-    chown -R debian:debian KlipperScreen
-    su -c "/home/debian/KlipperScreen/scripts/KlipperScreen-install.sh" debian
-}
-
-install_ustreamer() {
-    echo "🍰 install Ustreamer"
-    cd /home/debian
-    apt install -y build-essential libevent-dev libjpeg-dev libbsd-dev
-    git clone https://github.com/pikvm/ustreamer
-    cd /home/debian/ustreamer
-    make -j
-    echo 'SUBSYSTEM=="video4linux", ATTR{name}!="cedrus", ATTR{index}=="0", SYMLINK+="webcam", TAG+="systemd"' > /etc/udev/rules.d/50-video.rules
-    echo '%debian ALL=NOPASSWD: /bin/systemctl restart ustreamer.service' >> /etc/sudoers.d/debian
-    cp /tmp/overlay/ustreamer/ustreamer.service /etc/systemd/system/
-    systemctl enable ustreamer.service
-}
-
-install_autohotspot() {
-    echo "🍰 install Autohotspot"
-    # Install autohotspot script
-    cp /tmp/overlay/autohotspot/autohotspot /usr/local/bin
-    chmod +x /usr/local/bin/autohotspot
-
-    # Install autohotspot service file
-    cp /tmp/overlay/autohotspot/autohotspot.service /etc/systemd/system/
-
-    systemctl enable autohotspot.service
+run_ansible_playbook(){
+    cd /usr/src/Refactor
+    ansible-playbook SYSTEM_klipper_mainsail-DEFAULT.yml
 }
 
 prepare_build() {
@@ -135,8 +33,9 @@ prepare_build() {
     PACKAGE_LIST="avahi-daemon nginx git unzip iptables dnsmasq-base"
     PACKAGE_LIST+=" python3-virtualenv virtualenv python3-dev libffi-dev build-essential python3-cffi python3-libxml2"
     PACKAGE_LIST+=" libncurses-dev libusb-dev stm32flash libnewlib-arm-none-eabi gcc-arm-none-eabi binutils-arm-none-eabi "
+    PACKAGE_LIST+=" unzip libavahi-compat-libdnssd1 libnss-mdns cpufrequtils pv "
     apt update
-    apt install -y $PACKAGE_LIST
+    apt install -y "$PACKAGE_LIST"
 
     # Ensure the debian user exists
     useradd debian -d /home/debian -G tty,dialout -m -s /bin/bash -e -1
@@ -169,14 +68,8 @@ post_build() {
 set -e
 echo "🍰 Rebuild starting..."
 prepare_build
-install_klipper
-install_moonraker
-install_mainsail
-install_nginx
-install_klipperscreen
-install_ustreamer
-install_bins
-install_autohotspot
+install_ansible
+run_ansible_playbook
 post_build
 
 echo "🍰 Rebuild finished"

--- a/armbian/customize-image-mainsail.sh
+++ b/armbian/customize-image-mainsail.sh
@@ -25,7 +25,7 @@ install_ansible(){
 
 run_ansible_playbook(){
     cd /usr/src/Refactor
-    ansible-playbook SYSTEM_klipper_mainsail-DEFAULT.yml
+    ansible-playbook SYSTEM_klipper_mainsail-DEFAULT.yml --extra-vars='{"platform":"recore"}'
 }
 
 prepare_build() {

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -16,20 +16,20 @@ case $VERSION in
     ;; 
 esac
 
-if [ "x$LOCAL" == "xlocal" ]; then
+if [ "$LOCAL" == "local" ]; then
     BUILD_PREFIX="."
 else
     BUILD_PREFIX=".."
 fi
 
 BUILD_DIR="${BUILD_PREFIX}/build-${VERSION}"
-if ! test -d $BUILD_DIR ; then
+if ! test -d "$BUILD_DIR" ; then
     echo "$BUILD_DIR missing"
     git clone https://github.com/armbian/build $BUILD_DIR
 fi
 
-ROOT_DIR=`pwd`
-TAG=`git describe --always --tags`
+ROOT_DIR=$(pwd)
+TAG=$(git describe --always --tags)
 NAME="rebuild-${VERSION}-${TAG}"
 
 cd $BUILD_DIR
@@ -37,24 +37,24 @@ git checkout v23.05.2
 git pull
 rm -rf "userpatches"
 
-cd $ROOT_DIR
+cd "$ROOT_DIR"
 cp -r "userpatches" "${BUILD_DIR}"
-cp armbian/customize-image-${VERSION}.sh ${BUILD_DIR}/userpatches/customize-image.sh
-cp armbian/recore.csc ${BUILD_DIR}/config/boards
+cp armbian/customize-image-"${VERSION}".sh "${BUILD_DIR}"/userpatches/customize-image.sh
+cp armbian/recore.csc "${BUILD_DIR}"/config/boards
 rm -f "${BUILD_DIR}/patch/u-boot/u-boot-sunxi/allwinner-boot-splash.patch"
 
-if [ "x$VERSION" == "xreflash" ]; then
-    cp armbian/watermark-reflash.png ${BUILD_DIR}/packages/plymouth-theme-armbian/watermark.png
+if [ "$VERSION" == "reflash" ]; then
+    cp armbian/watermark-reflash.png "${BUILD_DIR}"/packages/plymouth-theme-armbian/watermark.png
 else
-    cp armbian/watermark.png ${BUILD_DIR}/packages/plymouth-theme-armbian/watermark.png
+    cp armbian/watermark.png "${BUILD_DIR}"/packages/plymouth-theme-armbian/watermark.png
 fi
 
-echo "${NAME}" > ${BUILD_DIR}/userpatches/overlay/rebuild/rebuild-version
+echo "${NAME}" > "${BUILD_DIR}"/userpatches/overlay/rebuild/rebuild-version
 
-cd $BUILD_DIR
+cd "$BUILD_DIR"
 DOCKER_EXTRA_ARGS="--cpus=12" ./compile.sh rebuild
-IMG=`ls -1 output/images/ | grep "img.xz$"`
+IMG=$(ls -1 output/images/ | grep "img.xz$")
 
-cd $ROOT_DIR
-mv $BUILD_DIR/output/images/$IMG "${BUILD_PREFIX}/images/${NAME}.img.xz"
+cd "$ROOT_DIR"
+mv "$BUILD_DIR"/output/images/"$IMG" "${BUILD_PREFIX}/images/${NAME}.img.xz"
 echo "🍰 Finished building ${NAME}"

--- a/userpatches/overlay/klipper/install-recore.sh
+++ b/userpatches/overlay/klipper/install-recore.sh
@@ -89,7 +89,7 @@ verify_ready()
 {
     if [ "$EUID" -eq 0 ]; then
         echo "This script must not run as root"
-        exit -1
+        exit 1
     fi
 }
 


### PR DESCRIPTION
This branch introduces a prototype of how to use the Ansible defined roles from Refactor within the Armbian image.
This should simplify maintaining the user-space application layer using Refactor, while keeping the image generation build system using the Armbian overlay build system.

In short, the division, while not perfect here, should aim to split responsibilities of the image packaging between the Rebuild and Refactor repos:

- Rebuild focuses on making a reliable and streamlined embedded Linux base for Recore (all revisions)
- Refactor focuses on providing userspace software (klipper, mainsail/fluidd/octoprint, ustreamer, etc.)

This PR needs https://github.com/intelligent-agent/Refactor/pull/376 to be merged as well to function - or we need to change the branch reference for testing at least.