### PR TITLE
Enhance/docker core count

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -13,12 +13,11 @@ case $VERSION in
         echo "Wrong argument '$1'"
         echo "Usage: $0 <barebone|mainsail|fluidd|octoprint|reflash>"
         exit 1
-    ;; 
+    ;;
 esac
 
 # Cores
 reported_cores=$(nproc --all)
-
 if [ ! -z $cores ] && [ $cores -gt $reported_cores ]; then
     echo "😿 Desired core count greater than reported available cores."
 elif [ ! -z $cores ] && [ $cores -lt 1 ]; then


### PR DESCRIPTION
Allow the user to define the core count used by docker when running rebuild.
If not defined, use all available cores.