### PR TITLE
Fix #65: make WiFi Client/Hotspot boot decision deterministic

### DIFF
--- a/userpatches/overlay/autohotspot/autohotspot
+++ b/userpatches/overlay/autohotspot/autohotspot
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 . /etc/rebuild-settings
+# Holds the plaintext wifi password - make sure it's root-only
+# regardless of how/when it was last written.
+chmod 600 /etc/rebuild-settings
 wifidev=`nmcli dev | grep "wifi " | cut -d' ' -f1`
 hotspot_SSID="Recore"
 hotspot_PW="12345678"

--- a/userpatches/overlay/autohotspot/autohotspot
+++ b/userpatches/overlay/autohotspot/autohotspot
@@ -4,6 +4,10 @@
 wifidev=`nmcli dev | grep "wifi " | cut -d' ' -f1`
 hotspot_SSID="Recore"
 hotspot_PW="12345678"
+# How long to wait for the configured network at boot before falling
+# back to the hotspot. Only boot-time availability matters here - if
+# the connection later drops, we deliberately do not fall back.
+CLIENT_TIMEOUT=30
 
 create_hotspot() {
   echo "Creating hotspot"
@@ -13,8 +17,9 @@ create_hotspot() {
   nmcli con modify Hotspot 802-11-wireless.channel 1
   nmcli con modify Hotspot ipv4.method shared
   nmcli con modify Hotspot ipv4.addresses 192.168.50.1/24
-  nmcli con modify Hotspot connection.autoconnect-priority -10
-  nmcli con modify Hotspot connection.autoconnect yes
+  # Brought up explicitly below, not left to NetworkManager's own
+  # autoconnect arbitration - see the Client/Hotspot race in #65.
+  nmcli con modify Hotspot connection.autoconnect no
   nmcli con modify Hotspot wifi-sec.key-mgmt wpa-psk
   nmcli con modify Hotspot wifi-sec.psk "$hotspot_PW"
 }
@@ -22,9 +27,9 @@ create_hotspot() {
 create_client() {
   echo "Creating wifi client config"
   nmcli con add type wifi ifname "$wifidev" con-name Client ssid "$WIFI_SSID"
+  nmcli con modify Client connection.autoconnect no
   nmcli con modify Client wifi-sec.key-mgmt wpa-psk
   nmcli con modify Client wifi-sec.psk "$WIFI_PSK"
-  nmcli con up Client || echo "Client connection setup, but failed to associate immediately."
 }
 
 if [ ! -f /etc/NetworkManager/system-connections/Hotspot.nmconnection ]; then
@@ -37,4 +42,21 @@ if [ ! -f /etc/NetworkManager/system-connections/Client.nmconnection ]; then
   else
     echo "No WIFI_SSID found in /etc/rebuild-settings. Skipping Client setup."
   fi
+fi
+
+# Decide which connection to bring up this boot. Both connections have
+# autoconnect disabled, so NetworkManager never arbitrates between them
+# itself - the choice is made explicitly, once, here.
+if [ -n "$WIFI_SSID" ] && [ -f /etc/NetworkManager/system-connections/Client.nmconnection ]; then
+  echo "Trying to connect to $WIFI_SSID (timeout ${CLIENT_TIMEOUT}s)..."
+  if nmcli -w "$CLIENT_TIMEOUT" con up Client; then
+    echo "Connected to $WIFI_SSID"
+  else
+    echo "Could not connect to $WIFI_SSID within ${CLIENT_TIMEOUT}s, falling back to hotspot"
+    nmcli con down Client 2>/dev/null
+    nmcli con up Hotspot
+  fi
+else
+  echo "No WIFI_SSID configured, starting hotspot"
+  nmcli con up Hotspot
 fi

--- a/userpatches/overlay/install_components/auto_disable_ssh.sh
+++ b/userpatches/overlay/install_components/auto_disable_ssh.sh
@@ -10,8 +10,11 @@ install_auto_disable_ssh() {
     cp /tmp/overlay/auto_disable_ssh/auto-disable-ssh.service /etc/systemd/system/
     cp /tmp/overlay/auto_disable_ssh/auto-disable-ssh.timer /etc/systemd/system/
 
-    # install settings file
+    # install settings file (will later hold the plaintext wifi
+    # password once Reflash writes real settings, so keep it
+    # root-only from the start)
     cp /tmp/overlay/auto_disable_ssh/rebuild-settings /etc/
+    chmod 600 /etc/rebuild-settings
 
     systemctl enable auto-disable-ssh.timer
 }


### PR DESCRIPTION
## Problem

Fixes #65. Both `Client` and `Hotspot` NetworkManager connections had `autoconnect` enabled with the Hotspot given a lower priority (-10), on the assumption NetworkManager would try Client first and fall back to Hotspot if it failed. In practice this race was unreliable - the Hotspot would very often come up even when the configured SSID was available.

## Fix

`autohotspot` now creates both connections with `connection.autoconnect no` and makes the choice explicitly, once, at boot - removing NetworkManager's own arbitration from the picture entirely:

- If `WIFI_SSID` is configured, try `nmcli -w 30 con up Client`.
- If that fails (or times out) within 30s, fall back to `nmcli con up Hotspot`.
- If no `WIFI_SSID` is configured at all, go straight to Hotspot.

Per discussion on the issue: this only falls back to hotspot if the configured SSID isn't reachable **at boot time**. If the connection later drops after a successful boot-time connect, that's not treated as a failure - we deliberately don't fall back mid-session.

Also locks down `/etc/rebuild-settings` to `600 root:root` right after it's sourced/copied, since it holds the plaintext WiFi PSK (`autohotspot` and `auto_disable_ssh.sh`) - matching NetworkManager's own storage model for the same secret.

## Test plan

Validated on real Recore hardware over serial console across three boot scenarios:
- [x] Configured SSID available at boot → connects as Client
- [x] Configured SSID unavailable at boot → falls back to Hotspot within the timeout
- [x] No `WIFI_SSID` configured at all → boots straight to Hotspot
- [x] Re-verified after a fresh Reflash-provisioned image (not just a re-tested device) - Client connection came up correctly on first boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)