### PR TITLE
Bump WiFi client connect timeout from 30s to 60s

### DIFF
--- a/userpatches/overlay/autohotspot/autohotspot
+++ b/userpatches/overlay/autohotspot/autohotspot
@@ -10,7 +10,7 @@ hotspot_PW="12345678"
 # How long to wait for the configured network at boot before falling
 # back to the hotspot. Only boot-time availability matters here - if
 # the connection later drops, we deliberately do not fall back.
-CLIENT_TIMEOUT=30
+CLIENT_TIMEOUT=60
 
 create_hotspot() {
   echo "Creating hotspot"


### PR DESCRIPTION
## Problem

Observed a real timeout on a 5GHz network in practice: the boot-time connection attempt hit the full 30s window and fell back to hotspot, even though the network was reachable (reconnecting manually right after succeeded within a few seconds).

5GHz scanning - particularly across DFS channels, which require slower passive scanning - can plausibly eat into a cold boot-time connect more than 30s comfortably allows.

## Why 60s

The cost is asymmetric: a longer timeout just means a slightly longer boot delay in the rare case the SSID truly isn't reachable at all, but a too-short timeout means falling back to hotspot even when the network *would* have connected given a few more seconds - which then needs manual intervention to fix. Per #65, the hotspot is meant to be a last-resort backup, not something to hit routinely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)