### PR TITLE
Fix Manga Screen 2 boot glitch (#77) and USB gadget setup (#75)

### DIFF
--- a/armbian/customize-image-barebone.sh
+++ b/armbian/customize-image-barebone.sh
@@ -35,10 +35,25 @@ post_build() {
     sed -i "s/PRETTY_NAME=\"/PRETTY_NAME=\"Rebuild ${TAG}\//" /etc/os-release
 
  cat <<EOF > /etc/udev/rules.d/99-recore-otg.rules
-# Trigger the ConfigFS script only when the role is 'device'
+# Bring the gadget up when the USB device controller appears. This is the
+# trigger that works on every revision: only the A8 device tree declares a
+# Type-C controller (fcs,fusb302 / usb-c-connector / usb-role-switch), so on
+# A5, A6 and A7 there is no usb_role class device at all, the role rule below
+# could never fire, and the board simply never enumerated - nothing in lsusb
+# on the host (#75). Reflash hit the same thing and moved to this trigger.
+SUBSYSTEM=="udc", ACTION=="add", TAG+="systemd", ENV{SYSTEMD_WANTS}="usb-gadget-setup.service"
+
+# Kept alongside the UDC rule rather than replaced by it. On A8 the role switch
+# tears the gadget down when the cable is unplugged or flipped to host, and
+# only this rule can bring it back: the UDC does not reappear, it is the
+# controller itself and is present regardless of cable state. Starting an
+# already-active oneshot with RemainAfterExit is a no-op, so the two triggers
+# do not fight.
 SUBSYSTEM=="usb_role", ATTR{role}=="device", RUN+="/usr/bin/systemctl start usb-gadget-setup.service"
 
-# Tear down the gadget if the cable is removed or switched to host
+# Tear down the gadget if the cable is removed or switched to host. These are
+# also role-based and so also A8-only; on A5-A7 they never fire and the gadget
+# stays up, which is what Reflash does on every revision.
 SUBSYSTEM=="usb_role", ATTR{role}=="none", RUN+="/usr/bin/systemctl stop usb-gadget-setup.service"
 SUBSYSTEM=="usb_role", ATTR{role}=="host", RUN+="/usr/bin/systemctl stop usb-gadget-setup.service"
 
@@ -50,11 +65,28 @@ EOF
 #!/bin/bash
 
 GADGET_DIR="/sys/kernel/config/usb_gadget/g1"
-UDC_NAME="musb-hdrc.4.auto"
 
 case "\$1" in
     start)
-        modprobe libcomposite
+        # usb_f_acm pulls in libcomposite and u_serial and registers the
+        # usb_gadget configfs subsystem.
+        modprobe usb_f_acm || { echo "modprobe usb_f_acm failed" >&2; exit 1; }
+
+        # configfs registration is asynchronous - wait for it rather than
+        # racing it.
+        for i in \$(seq 1 50); do
+            [ -d /sys/kernel/config/usb_gadget ] && break
+            sleep 0.1
+        done
+        [ -d /sys/kernel/config/usb_gadget ] || { echo "usb_gadget configfs unavailable" >&2; exit 1; }
+
+        # Bind to whichever UDC exists instead of a hardcoded name. The musb
+        # platform device instance number comes from device tree ordering, so
+        # it is not the same everywhere - this board has musb-hdrc.4.auto,
+        # while Reflash's universal DTB gives musb-hdrc.2.auto.
+        UDC_NAME="\$(ls /sys/class/udc 2>/dev/null | head -1)"
+        [ -n "\$UDC_NAME" ] || { echo "no UDC available" >&2; exit 1; }
+
         mkdir -p \$GADGET_DIR
         cd \$GADGET_DIR
 
@@ -75,7 +107,7 @@ case "\$1" in
         ln -s functions/acm.usb0 configs/c.1/ 2>/dev/null
 
         # Bind to hardware
-        echo \$UDC_NAME > UDC
+        echo "\$UDC_NAME" > UDC
         ;;
     stop)
         if [ -d "\$GADGET_DIR" ]; then

--- a/userpatches/overlay/install_components/post_build.sh
+++ b/userpatches/overlay/install_components/post_build.sh
@@ -30,10 +30,25 @@ post_build() {
 
 
     cat <<EOF > /etc/udev/rules.d/99-recore-otg.rules
-# Trigger the ConfigFS script only when the role is 'device'
+# Bring the gadget up when the USB device controller appears. This is the
+# trigger that works on every revision: only the A8 device tree declares a
+# Type-C controller (fcs,fusb302 / usb-c-connector / usb-role-switch), so on
+# A5, A6 and A7 there is no usb_role class device at all, the role rule below
+# could never fire, and the board simply never enumerated - nothing in lsusb
+# on the host (#75). Reflash hit the same thing and moved to this trigger.
+SUBSYSTEM=="udc", ACTION=="add", TAG+="systemd", ENV{SYSTEMD_WANTS}="usb-gadget-setup.service"
+
+# Kept alongside the UDC rule rather than replaced by it. On A8 the role switch
+# tears the gadget down when the cable is unplugged or flipped to host, and
+# only this rule can bring it back: the UDC does not reappear, it is the
+# controller itself and is present regardless of cable state. Starting an
+# already-active oneshot with RemainAfterExit is a no-op, so the two triggers
+# do not fight.
 SUBSYSTEM=="usb_role", ATTR{role}=="device", RUN+="/usr/bin/systemctl start usb-gadget-setup.service"
 
-# Tear down the gadget if the cable is removed or switched to host
+# Tear down the gadget if the cable is removed or switched to host. These are
+# also role-based and so also A8-only; on A5-A7 they never fire and the gadget
+# stays up, which is what Reflash does on every revision.
 SUBSYSTEM=="usb_role", ATTR{role}=="none", RUN+="/usr/bin/systemctl stop usb-gadget-setup.service"
 SUBSYSTEM=="usb_role", ATTR{role}=="host", RUN+="/usr/bin/systemctl stop usb-gadget-setup.service"
 
@@ -45,11 +60,28 @@ EOF
 #!/bin/bash
 
 GADGET_DIR="/sys/kernel/config/usb_gadget/g1"
-UDC_NAME="musb-hdrc.4.auto"
 
 case "\$1" in
     start)
-        modprobe libcomposite
+        # usb_f_acm pulls in libcomposite and u_serial and registers the
+        # usb_gadget configfs subsystem.
+        modprobe usb_f_acm || { echo "modprobe usb_f_acm failed" >&2; exit 1; }
+
+        # configfs registration is asynchronous - wait for it rather than
+        # racing it.
+        for i in \$(seq 1 50); do
+            [ -d /sys/kernel/config/usb_gadget ] && break
+            sleep 0.1
+        done
+        [ -d /sys/kernel/config/usb_gadget ] || { echo "usb_gadget configfs unavailable" >&2; exit 1; }
+
+        # Bind to whichever UDC exists instead of a hardcoded name. The musb
+        # platform device instance number comes from device tree ordering, so
+        # it is not the same everywhere - this board has musb-hdrc.4.auto,
+        # while Reflash's universal DTB gives musb-hdrc.2.auto.
+        UDC_NAME="\$(ls /sys/class/udc 2>/dev/null | head -1)"
+        [ -n "\$UDC_NAME" ] || { echo "no UDC available" >&2; exit 1; }
+
         mkdir -p \$GADGET_DIR
         cd \$GADGET_DIR
 
@@ -70,7 +102,7 @@ case "\$1" in
         ln -s functions/acm.usb0 configs/c.1/ 2>/dev/null
 
         # Bind to hardware
-        echo \$UDC_NAME > UDC
+        echo "\$UDC_NAME" > UDC
         ;;
     stop)
         if [ -d "\$GADGET_DIR" ]; then

--- a/userpatches/u-boot/u-boot-sunxi/u-boot-sunxi64-legacy-6-usb-phy-keep-reset-deasserted.patch
+++ b/userpatches/u-boot/u-boot-sunxi/u-boot-sunxi64-legacy-6-usb-phy-keep-reset-deasserted.patch
@@ -1,0 +1,58 @@
+From: Elias Bakken <elias@iagent.no>
+Subject: [PATCH] phy: sun4i-usb: do not assert the phy reset on exit
+
+Asserting the USB phy reset in sun4i_usb_phy_exit() disturbs the display
+output timing during the u-boot -> Linux handover. On a Recore A7 driving a
+Manga Screen 2 (720x1280@57Hz, TC358870 HDMI->DSI bridge) the panel loses
+HDMI lock roughly 40ms before "Starting kernel", which the user sees as a
+flicker and sometimes a blank or stale image.
+
+The panel reports "(Input side) HV counter change", "DE size and position
+change" and "(Output side) H counter change", with no TMDS-amplitude, no
+DDC-power and no PHY-PLL bits: the signal and its clock are intact and only
+the output timing moves. Nothing in Linux reprograms the display afterwards
+because the framebuffer is handed to simpledrm, so the disturbance is not
+masked and the panel has to re-lock.
+
+Isolated by bracketing each step of the teardown with 2s stalls: in 2 of 3
+boots the panel reacted inside the ~3ms window where reset_assert() runs,
+while disable_interrupts(), passby-off, clk_disable and the identical
+reset_assert() on phy0 were silent across every boot. phy0 is the idle OTG
+phy; phy1 serves the populated bus, which is why only phy1 shows it.
+
+Dropping the reset is safe. usb_stop() has already removed the EHCI/OHCI
+controllers by this point, and halting them is what stops OHCI busmastering
+into SDRAM - the reason usb_stop() exists. The reset contributes nothing to
+that, and Linux re-initialises the phy on probe regardless.
+
+Measured on a Recore A7: 9 of 11 boots disturbed before, 0 of 12 after, with
+no change in USB device enumeration or ehci/ohci errors.
+
+Signed-off-by: Elias Bakken <elias@iagent.no>
+---
+ drivers/phy/allwinner/phy-sun4i-usb.c | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+--- a/drivers/phy/allwinner/phy-sun4i-usb.c
++++ b/drivers/phy/allwinner/phy-sun4i-usb.c
+@@ -352,12 +352,14 @@ static int sun4i_usb_phy_exit(struct phy *phy)
+ 		return ret;
+ 	}
+
+-	ret = reset_assert(&usb_phy->resets);
+-	if (ret) {
+-		dev_err(phy->dev, "failed to assert usb_%ldreset reset\n",
+-			phy->id);
+-		return ret;
+-	}
++	/*
++	 * Deliberately do not assert the phy reset here.  It perturbs the
++	 * display output timing while the DE is still driving the u-boot
++	 * splash, and simpledrm never reprograms the display, so the panel
++	 * has to re-lock - visible as a flicker or a blank screen.  The
++	 * controllers have already been removed by usb_stop(), which is what
++	 * stops OHCI busmastering into SDRAM; the reset adds nothing to that.
++	 */
+
+ 	return 0;
+ }


### PR DESCRIPTION
Two independent fixes, both validated on hardware.

## u-boot: don't assert the USB phy reset on exit (#77)

Asserting the USB phy reset in `sun4i_usb_phy_exit()` perturbs display output timing during the u-boot → Linux handover, so the Manga Screen 2 loses HDMI lock ~40ms before `Starting kernel` and has to re-lock — seen as a flicker, sometimes a blank or stale image. simpledrm never reprograms the display, so nothing masks it.

Isolated by bracketing each teardown step with 2s stalls: the panel reacted inside the ~3ms window where `reset_assert()` runs, while `disable_interrupts()`, passby-off, `clk_disable` and the identical `reset_assert()` on **phy0** were silent in every boot. phy0 is the idle OTG phy; phy1 serves the populated bus — consistent with a load transient rather than the register write itself.

Safe because `usb_stop()` has already removed the EHCI/OHCI controllers, and halting them is what stops OHCI busmastering into SDRAM (the reason `usb_stop()` exists). Linux re-initialises the phy on probe regardless.

| configuration | boots | disturbed |
|---|---|---|
| reset asserted (before) | 20 | 11 |
| reset skipped (after) | 30 | **0** |

p ≈ 2e-6. Scored on disturbances **after** the panel locks — extra pre-lock retries are the panel acquiring u-boot's signal and are benign. No change in USB enumeration or ehci/ohci errors. Smoke-tested on a Recore A8 with a Renits A5 and five USB devices.

0/30 bounds the true rate at ~10% (95% CI); a 1-in-100 claim would need ~300 boots. One unexplained post-lock event remains across 65 fix-on boots.

## usb gadget: trigger on the udc device and derive its name (#75)

The gadget setup raced its own preconditions: the udev rule only matched `usb_role` so nothing triggered on the udc appearing, `UDC_NAME` was hardcoded, and configfs/`usb_f_acm` were assumed present. Adds a `SUBSYSTEM=="udc"` rule with `SYSTEMD_WANTS`, derives the name from `/sys/class/udc`, and modprobes `usb_f_acm` with a bounded wait.

Note: validated on an A7; an A8 is now on the bench for the second check.